### PR TITLE
Move the call to the updater in Java FX thread when an exception occured

### DIFF
--- a/gse-network-explorer/src/main/java/com/powsybl/gse/explorer/NetworkExplorer.java
+++ b/gse-network-explorer/src/main/java/com/powsybl/gse/explorer/NetworkExplorer.java
@@ -226,8 +226,10 @@ class NetworkExplorer extends BorderPane implements ProjectFileViewer, ProjectCa
                     }
                 }
             } catch (Throwable t) {
-                updater.accept(null);
-                Platform.runLater(() -> GseUtil.showDialogError(t));
+                Platform.runLater(() -> {
+                    updater.accept(null);
+                    GseUtil.showDialogError(t);
+                });
             }
         });
     }

--- a/gse-network-explorer/src/main/java/com/powsybl/gse/explorer/NetworkExplorer.java
+++ b/gse-network-explorer/src/main/java/com/powsybl/gse/explorer/NetworkExplorer.java
@@ -225,10 +225,10 @@ class NetworkExplorer extends BorderPane implements ProjectFileViewer, ProjectCa
                         throw new UncheckedIOException(e);
                     }
                 }
-            } catch (Throwable t) {
+            } catch (Exception e) {
                 Platform.runLater(() -> {
                     updater.accept(null);
-                    GseUtil.showDialogError(t);
+                    GseUtil.showDialogError(e);
                 });
             }
         });

--- a/gse-network-explorer/src/main/java/com/powsybl/gse/explorer/NetworkExplorer.java
+++ b/gse-network-explorer/src/main/java/com/powsybl/gse/explorer/NetworkExplorer.java
@@ -28,8 +28,6 @@ import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.paint.Color;
 import javafx.scene.text.Text;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -44,7 +42,6 @@ import java.util.function.Function;
  */
 class NetworkExplorer extends BorderPane implements ProjectFileViewer, ProjectCaseListener {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(NetworkExplorer.class);
     private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle("lang.NetworkExplorer");
 
     private static final IdAndName BUSY = new IdAndName("...", "...");
@@ -97,9 +94,6 @@ class NetworkExplorer extends BorderPane implements ProjectFileViewer, ProjectCa
 
         private String type;
 
-        public EquipmentQueryResult() {
-        }
-
         public IdAndName getIdAndName() {
             return idAndName;
         }
@@ -122,9 +116,6 @@ class NetworkExplorer extends BorderPane implements ProjectFileViewer, ProjectCa
         private IdAndName idAndName;
 
         private List<EquipmentQueryResult> equipments;
-
-        public VoltageLevelQueryResult() {
-        }
 
         public IdAndName getIdAndName() {
             return idAndName;
@@ -287,6 +278,26 @@ class NetworkExplorer extends BorderPane implements ProjectFileViewer, ProjectCa
         }, substationExecutor);
     }
 
+    private void fillSubstationDetailViewWithQueryResults(IdAndName substationIdAndName, List<VoltageLevelQueryResult> voltageLevelQueryResults) {
+        if (voltageLevelQueryResults != null) {
+            TreeItem<IdAndName> substationItem = new TreeItem<>(substationIdAndName);
+            substationItem.setExpanded(true);
+            for (VoltageLevelQueryResult voltageLevelQueryResult : voltageLevelQueryResults) {
+                TreeItem<IdAndName> voltageLevelItem = new TreeItem<>(voltageLevelQueryResult.getIdAndName());
+                substationItem.getChildren().add(voltageLevelItem);
+                for (EquipmentQueryResult equipmentQueryResult : voltageLevelQueryResult.getEquipments()) {
+                    Node icon = getIcon(equipmentQueryResult.getType());
+                    TreeItem<IdAndName> equipmentItem = new TreeItem<>(equipmentQueryResult.getIdAndName(), icon);
+                    voltageLevelItem.getChildren().add(equipmentItem);
+                }
+                voltageLevelItem.setExpanded(true);
+            }
+            substationDetailedView.setRoot(substationItem);
+        } else {
+            substationDetailedView.setRoot(null);
+        }
+    }
+
     private void refreshSubstationDetailView(IdAndName substationIdAndName) {
         if (substationIdAndName != null && substationIdAndName != BUSY) {
             substationDetailedView.setRoot(new TreeItem<>(BUSY));
@@ -310,31 +321,16 @@ class NetworkExplorer extends BorderPane implements ProjectFileViewer, ProjectCa
                     "    ]",
                     "}",
                     "");
-            queryNetwork(query, voltageLevelQueryResultListType, (List<VoltageLevelQueryResult> voltageLevelQueryResults) -> {
-                if (voltageLevelQueryResults != null) {
-                    TreeItem<IdAndName> substationItem = new TreeItem<>(substationIdAndName);
-                    substationItem.setExpanded(true);
-                    for (VoltageLevelQueryResult voltageLevelQueryResult : voltageLevelQueryResults) {
-                        TreeItem<IdAndName> voltageLevelItem = new TreeItem<>(voltageLevelQueryResult.getIdAndName());
-                        substationItem.getChildren().add(voltageLevelItem);
-                        for (EquipmentQueryResult equipmentQueryResult : voltageLevelQueryResult.getEquipments()) {
-                            Node icon = getIcon(equipmentQueryResult.getType());
-                            TreeItem<IdAndName> equipmentItem = new TreeItem<>(equipmentQueryResult.getIdAndName(), icon);
-                            voltageLevelItem.getChildren().add(equipmentItem);
-                        }
-                        voltageLevelItem.setExpanded(true);
-                    }
-                    substationDetailedView.setRoot(substationItem);
-                } else {
-                    substationDetailedView.setRoot(null);
-                }
-            }, substationDetailsExecutor);
+            queryNetwork(query, voltageLevelQueryResultListType,
+                (List<VoltageLevelQueryResult> voltageLevelQueryResults) -> fillSubstationDetailViewWithQueryResults(substationIdAndName, voltageLevelQueryResults),
+                substationDetailsExecutor);
         } else {
             substationDetailedView.setRoot(null);
         }
     }
 
     private void refreshEquipmentView(TreeItem<IdAndName> equipmentIdAndName) {
+        //TODO to be used to fill per equipment details
     }
 
     @Override


### PR DESCRIPTION
While trying to work on groovy queries to complete the network explorer interface, I discovered an issue in the exception management.
Updater method after exception was not run in the JavaFX thread causing an Exception that stopped correct behavior off the app.