### PR TITLE
Improvements in network explorer

### DIFF
--- a/gse-network-explorer/src/main/java/com/powsybl/gse/explorer/NetworkExplorer.java
+++ b/gse-network-explorer/src/main/java/com/powsybl/gse/explorer/NetworkExplorer.java
@@ -134,6 +134,7 @@ class NetworkExplorer extends BorderPane implements ProjectFileViewer, ProjectCa
         showName.selectedProperty().addListener((observable, oldValue, newValue) -> {
             substationsView.refresh();
             substationDetailedView.refresh();
+            refreshEquipmentView(substationDetailedView.getSelectionModel().getSelectedItem());
         });
 
         substationFilterInput.textProperty().addListener(obs -> {
@@ -287,6 +288,7 @@ class NetworkExplorer extends BorderPane implements ProjectFileViewer, ProjectCa
     }
 
     private void fillSubstationDetailViewWithQueryResults(IdAndName substationIdAndName, List<VoltageLevelQueryResult> voltageLevelQueryResults) {
+        equipmentTabs.getTabs().clear();
         if (voltageLevelQueryResults != null) {
             TreeItem<EquipmentInfo> substationItem = new TreeItem<>(new EquipmentInfo(substationIdAndName, "SUBSTATION"));
             substationItem.setExpanded(true);
@@ -329,8 +331,8 @@ class NetworkExplorer extends BorderPane implements ProjectFileViewer, ProjectCa
             linePiModelDiagram.g2Property().set(result.getG2());
             linePiModelDiagram.b1Property().set(result.getB1());
             linePiModelDiagram.b2Property().set(result.getB2());
-            linePiModelDiagram.voltageLevel1Property().set(result.getVoltageLevel1());
-            linePiModelDiagram.voltageLevel2Property().set(result.getVoltageLevel2());
+            linePiModelDiagram.voltageLevel1Property().set(showName.isSelected() ? result.getNameVoltageLevel1() : result.getIdVoltageLevel1());
+            linePiModelDiagram.voltageLevel2Property().set(showName.isSelected() ? result.getNameVoltageLevel2() : result.getIdVoltageLevel2());
         }, equipmentExecutor);
     }
 

--- a/gse-network-explorer/src/main/java/com/powsybl/gse/explorer/diagrams/LinePiModelDiagram.java
+++ b/gse-network-explorer/src/main/java/com/powsybl/gse/explorer/diagrams/LinePiModelDiagram.java
@@ -15,6 +15,7 @@ import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.SimpleDoubleProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
+import javafx.scene.control.Tooltip;
 import javafx.scene.layout.Pane;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Circle;
@@ -22,10 +23,14 @@ import javafx.scene.shape.Line;
 import javafx.scene.text.Text;
 import javafx.scene.text.TextAlignment;
 
+import java.util.Objects;
+
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public class LinePiModelDiagram extends Pane {
+
+    private static final int MAX_NAME_ID_LENGTH = 15;
 
     private final DoubleProperty r = new SimpleDoubleProperty(Double.NaN);
 
@@ -164,10 +169,16 @@ public class LinePiModelDiagram extends Pane {
         b2Text.setTextAlignment(TextAlignment.CENTER);
 
         Text voltageLevel1Text = new Text(15, 40, "");
-        voltageLevel1Text.textProperty().bind(voltageLevel1);
+        voltageLevel1Text.textProperty().bind(Bindings.createStringBinding(() -> formatNameId(this.voltageLevel1), this.voltageLevel1));
+        Tooltip tooltipVoltageLevel1 = new Tooltip();
+        tooltipVoltageLevel1.textProperty().bind(this.voltageLevel1);
+        Tooltip.install(voltageLevel1Text, tooltipVoltageLevel1);
 
         Text voltageLevel2Text = new Text(365, 40, "");
-        voltageLevel2Text.textProperty().bind(voltageLevel2);
+        voltageLevel2Text.textProperty().bind(Bindings.createStringBinding(() -> formatNameId(this.voltageLevel2), this.voltageLevel2));
+        Tooltip tooltipVoltageLevel2 = new Tooltip();
+        tooltipVoltageLevel2.textProperty().bind(this.voltageLevel2);
+        Tooltip.install(voltageLevel2Text, tooltipVoltageLevel2);
 
         getChildren().addAll(rSymbol, xSymbol, g1Symbol, b1Symbol, g2Symbol, b2Symbol,
                 ground1, ground2,
@@ -183,6 +194,14 @@ public class LinePiModelDiagram extends Pane {
 
     private static String formatSiemens(DoubleProperty d) {
         return Double.isNaN(d.get()) ? "?" : String.format("%.3e", d.get());
+    }
+
+    private static String formatNameId(StringProperty s) {
+        String nameId = s.get();
+        if (Objects.isNull(nameId)) {
+            return "?";
+        }
+        return nameId.length() <= MAX_NAME_ID_LENGTH ? nameId : nameId.substring(0, MAX_NAME_ID_LENGTH - 3) + "...";
     }
 
     public DoubleProperty rProperty() {

--- a/gse-network-explorer/src/main/java/com/powsybl/gse/explorer/query/LineQueryResult.java
+++ b/gse-network-explorer/src/main/java/com/powsybl/gse/explorer/query/LineQueryResult.java
@@ -23,9 +23,13 @@ public class LineQueryResult {
 
     private double b2;
 
-    private String voltageLevel1;
+    private String idVoltageLevel1;
 
-    private String voltageLevel2;
+    private String idVoltageLevel2;
+
+    private String nameVoltageLevel1;
+
+    private String nameVoltageLevel2;
 
     public double getR() {
         return r;
@@ -75,19 +79,35 @@ public class LineQueryResult {
         this.b2 = b2;
     }
 
-    public String getVoltageLevel1() {
-        return voltageLevel1;
+    public String getIdVoltageLevel1() {
+        return idVoltageLevel1;
     }
 
-    public void setVoltageLevel1(String voltageLevel1) {
-        this.voltageLevel1 = voltageLevel1;
+    public void setIdVoltageLevel1(String idVoltageLevel1) {
+        this.idVoltageLevel1 = idVoltageLevel1;
     }
 
-    public String getVoltageLevel2() {
-        return voltageLevel2;
+    public String getIdVoltageLevel2() {
+        return idVoltageLevel2;
     }
 
-    public void setVoltageLevel2(String voltageLevel2) {
-        this.voltageLevel2 = voltageLevel2;
+    public void setIdVoltageLevel2(String idVoltageLevel2) {
+        this.idVoltageLevel2 = idVoltageLevel2;
+    }
+
+    public String getNameVoltageLevel1() {
+        return nameVoltageLevel1;
+    }
+
+    public void setNameVoltageLevel1(String nameVoltageLevel1) {
+        this.nameVoltageLevel1 = nameVoltageLevel1;
+    }
+
+    public String getNameVoltageLevel2() {
+        return nameVoltageLevel2;
+    }
+
+    public void setNameVoltageLevel2(String nameVoltageLevel2) {
+        this.nameVoltageLevel2 = nameVoltageLevel2;
     }
 }

--- a/gse-network-explorer/src/main/resources/ftl/lineQuery.ftl
+++ b/gse-network-explorer/src/main/resources/ftl/lineQuery.ftl
@@ -6,6 +6,8 @@ def l = network.getLine('${lineId}')
    g2: l.g2,
    b1: l.b1,
    b2: l.b2,
-   voltageLevel1: l.terminal1.voltageLevel.id,
-   voltageLevel2: l.terminal2.voltageLevel.id
+   idVoltageLevel1: l.terminal1.voltageLevel.id,
+   idVoltageLevel2: l.terminal2.voltageLevel.id,
+   nameVoltageLevel1: l.terminal1.voltageLevel.name,
+   nameVoltageLevel2: l.terminal2.voltageLevel.name
 ]


### PR DESCRIPTION
Improvements in network explorer:
- "Show name" checkbox now also switch between ID and name for the voltage levels in line model diagram
- Solve an incorrect refresh of the equipment tab when selecting a substation
- Limit the admissible length of voltage levels ID/name in line model diagram (and add a tooltip with complete ID/name)