### PR TITLE
Fix drop towards projectFile feature

### DIFF
--- a/gse-app/src/main/java/com/powsybl/gse/app/ProjectPane.java
+++ b/gse-app/src/main/java/com/powsybl/gse/app/ProjectPane.java
@@ -331,7 +331,11 @@ public class ProjectPane extends Tab {
     private void dragOverEvent(DragEvent event, Object item, TreeItem<Object> treeItem, TreeCell<Object> treeCell) {
         if (item instanceof ProjectNode && isMovable(item, treeItem)) {
             int count = 0;
-            treeItemChildrenSize(treeItem, count);
+            if (item instanceof ProjectFolder) {
+                treeItemChildrenSize(treeItem, count);
+            } else {
+                treeItemChildrenSize(treeItem.getParent(), count);
+            }
             setDragOverStyle(treeCell);
             event.acceptTransferModes(TransferMode.ANY);
             event.consume();
@@ -360,7 +364,11 @@ public class ProjectPane extends Tab {
         if (value != dragAndDropMove.getSource()) {
             int count = 0;
             success = false;
-            treeItemChildrenSize(treeItem, count);
+            if (value instanceof ProjectFolder) {
+                treeItemChildrenSize(treeItem, count);
+            } else {
+                treeItemChildrenSize(treeItem.getParent(), count);
+            }
             if (value instanceof ProjectFolder) {
                 ProjectFolder projectFolder = (ProjectFolder) projectNode;
                 acceptTransferDrag(projectFolder, success);
@@ -385,7 +393,7 @@ public class ProjectPane extends Tab {
                 for (ProjectNode node : treeItemFolder.getChildren()) {
                     if (node == null) {
                         break;
-                    } else if (node.getName().equals(dragAndDropMove.getSource().toString())) {
+                    } else if (node.getName().equals(((ProjectNode) dragAndDropMove.getSource()).getName())) {
                         counter++;
                     }
                 }

--- a/gse-app/src/main/java/com/powsybl/gse/app/ProjectPane.java
+++ b/gse-app/src/main/java/com/powsybl/gse/app/ProjectPane.java
@@ -313,8 +313,19 @@ public class ProjectPane extends Tab {
         return targetTreeItem == dragAndDropMove.getSourceTreeItem().getParent();
     }
 
-    public boolean isMovable(Object item, TreeItem<Object> targetTreeItem) {
-        return dragAndDropMove != null && item != dragAndDropMove.getSource() && !isSourceAncestorOf(targetTreeItem) && !isChildOf(targetTreeItem);
+    private boolean isMovable(Object item, TreeItem<Object> targetTreeItem) {
+        return dragAndDropMove != null && item != dragAndDropMove.getSource() && !isSourceAncestorOf(targetTreeItem) && !isChildOf(targetTreeItem) && !areSourceAndTargetProjectFileSiblings(item);
+    }
+
+    private boolean areSourceAndTargetProjectFileSiblings(Object targetItem) {
+        Object sourceItem = dragAndDropMove.getSource();
+        Optional<ProjectFolder> sourceParent = ((ProjectNode) sourceItem).getParent();
+        Optional<ProjectFolder> targetParent = ((ProjectNode) targetItem).getParent();
+        if (sourceParent.isPresent() && targetParent.isPresent()) {
+            return sourceItem instanceof ProjectFile && targetItem instanceof ProjectFile && sourceParent.get().getId().equals(targetParent.get().getId());
+        } else {
+            return false;
+        }
     }
 
     private void dragOverEvent(DragEvent event, Object item, TreeItem<Object> treeItem, TreeCell<Object> treeCell) {


### PR DESCRIPTION
-while dragging a node towards a ProjectFile , the source node should not have the same parent as the target node nor the same name as one of the target's parent children