### PR TITLE
replace searching Pattern  metacharcters

### DIFF
--- a/gse-util/src/main/java/com/powsybl/gse/util/GroovyCodeEditor.java
+++ b/gse-util/src/main/java/com/powsybl/gse/util/GroovyCodeEditor.java
@@ -150,15 +150,16 @@ public class GroovyCodeEditor extends MasterDetailPane {
         String replaceText = searchBar.getReplaceText();
         int ci = Pattern.CASE_INSENSITIVE;
         String code;
+        String value = SearchBar.escapeMetaCharacters(wordToReplace);
         if (!wordSensitive) {
-            code = caseSensitive ? StringUtils.replacePattern(text, wordToReplace, replaceText) : Pattern.compile(wordToReplace, ci).matcher(text).replaceAll(replaceText);
+            code = caseSensitive ? StringUtils.replacePattern(text, value, replaceText) : Pattern.compile(value, ci).matcher(text).replaceAll(replaceText);
         } else {
-            Matcher matcher = caseSensitive ? Pattern.compile("\\W" + wordToReplace + "\\W").matcher(text) : Pattern.compile("\\W" + wordToReplace + "\\W", ci).matcher(text);
+            Matcher matcher = caseSensitive ? Pattern.compile("\\W" + value + "\\W").matcher(text) : Pattern.compile("\\W" + value + "\\W", ci).matcher(text);
             String txt = text;
             while (matcher.find()) {
                 int length = txt.length();
                 txt = txt.substring(0, matcher.start() + 1) + replaceText + txt.substring(matcher.end() - 1, length);
-                matcher = caseSensitive ? Pattern.compile("\\W" + wordToReplace + "\\W").matcher(txt) : Pattern.compile("\\W" + wordToReplace + "\\W", ci).matcher(txt);
+                matcher = caseSensitive ? Pattern.compile("\\W" + value + "\\W").matcher(txt) : Pattern.compile("\\W" + value + "\\W", ci).matcher(txt);
             }
             code = txt;
         }

--- a/gse-util/src/main/java/com/powsybl/gse/util/SearchBar.java
+++ b/gse-util/src/main/java/com/powsybl/gse/util/SearchBar.java
@@ -132,13 +132,14 @@ public final class SearchBar extends HBox {
         }
 
         void find(String searchPattern, String searchedTxt, boolean caseSensitive, boolean wordSensitive) {
+            String value = escapeMetaCharacters(searchPattern);
             reset();
             try {
                 Matcher sensitiveMatcher;
                 if (!wordSensitive) {
-                    sensitiveMatcher = caseSensitive ? Pattern.compile(searchPattern).matcher(searchedTxt) : Pattern.compile(searchPattern, Pattern.CASE_INSENSITIVE).matcher(searchedTxt);
+                    sensitiveMatcher = caseSensitive ? Pattern.compile(value).matcher(searchedTxt) : Pattern.compile(value, Pattern.CASE_INSENSITIVE).matcher(searchedTxt);
                 } else {
-                    sensitiveMatcher = caseSensitive ? Pattern.compile("\\W" + searchPattern + "\\W").matcher(searchedTxt) : Pattern.compile("\\W" + searchPattern + "\\W", Pattern.CASE_INSENSITIVE).matcher(searchedTxt);
+                    sensitiveMatcher = caseSensitive ? Pattern.compile("\\W" + value + "\\W").matcher(searchedTxt) : Pattern.compile("\\W" + value + "\\W", Pattern.CASE_INSENSITIVE).matcher(searchedTxt);
                 }
                 while (sensitiveMatcher.find()) {
                     positions.add(wordSensitive ? new SearchTuple(sensitiveMatcher.start() + 1, sensitiveMatcher.end() - 1) : new SearchTuple(sensitiveMatcher.start(), sensitiveMatcher.end()));
@@ -222,8 +223,7 @@ public final class SearchBar extends HBox {
             if (newValue == null || "".equals(newValue)) {
                 refresh(textArea);
             } else {
-                String value = escapeMetaCharacters(newValue);
-                matcher.find(value, searchedArea.getText(), caseSensitiveBox.selectedProperty().get(), wordSensitiveBox.selectedProperty().get());
+                matcher.find(newValue, searchedArea.getText(), caseSensitiveBox.selectedProperty().get(), wordSensitiveBox.selectedProperty().get());
             }
         });
 
@@ -265,7 +265,7 @@ public final class SearchBar extends HBox {
         replaceWordBar.replaceButton.disableProperty().bind(validateDisableProperty());
     }
 
-    private static String escapeMetaCharacters(String value) {
+    public static String escapeMetaCharacters(String value) {
         List<Character> metaCharacters = Arrays.asList('.', '*', '\\', '(', ')', '[', ']', '{', '}', '^', '$', '|', '+', '?');
         String replacement = value;
         for (Character ch : metaCharacters) {

--- a/gse-util/src/main/java/com/powsybl/gse/util/SearchBar.java
+++ b/gse-util/src/main/java/com/powsybl/gse/util/SearchBar.java
@@ -35,6 +35,7 @@ import org.controlsfx.control.textfield.TextFields;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Arrays;
 import java.util.Objects;
 import java.util.ResourceBundle;
 import java.util.regex.Matcher;
@@ -221,7 +222,8 @@ public final class SearchBar extends HBox {
             if (newValue == null || "".equals(newValue)) {
                 refresh(textArea);
             } else {
-                matcher.find(newValue, searchedArea.getText(), caseSensitiveBox.selectedProperty().get(), wordSensitiveBox.selectedProperty().get());
+                String value = escapeMetaCharacters(newValue);
+                matcher.find(value, searchedArea.getText(), caseSensitiveBox.selectedProperty().get(), wordSensitiveBox.selectedProperty().get());
             }
         });
 
@@ -261,6 +263,17 @@ public final class SearchBar extends HBox {
 
         replaceWordBar.replaceAllButton.disableProperty().bind(validateDisableProperty());
         replaceWordBar.replaceButton.disableProperty().bind(validateDisableProperty());
+    }
+
+    private static String escapeMetaCharacters(String value) {
+        List<Character> metaCharacters = Arrays.asList('.', '*', '\\', '(', ')', '[', ']', '{', '}', '^', '$', '|', '+', '?');
+        String replacement = value;
+        for (Character ch : metaCharacters) {
+            if (value.contains(Character.toString(ch))) {
+                replacement = replacement.replace(Character.toString(ch), "\\" + ch);
+            }
+        }
+        return replacement;
     }
 
     private BooleanBinding validateDisableProperty() {


### PR DESCRIPTION
when searching for a word that contains regular expressions, characters such as '(' or '{',  are mistaken
with Meta Characters. that mistake throws a PatternSyntaxException