### PR TITLE
Prevent deletion of parent and child nodes

### DIFF
--- a/gse-app/src/main/java/com/powsybl/gse/app/ProjectPane.java
+++ b/gse-app/src/main/java/com/powsybl/gse/app/ProjectPane.java
@@ -626,6 +626,8 @@ public class ProjectPane extends Tab {
         MenuItem deleteMenuItem = new MenuItem(RESOURCE_BUNDLE.getString("Delete"), Glyph.createAwesomeFont('\uf1f8').size("1.1em"));
         deleteMenuItem.setOnAction(event -> deleteNodesAlert(selectedTreeItems));
         deleteMenuItem.setAccelerator(new KeyCodeCombination(KeyCode.DELETE));
+        List<TreeItem<Object>> selectedItems = new ArrayList<>(selectedTreeItems);
+        deleteMenuItem.setDisable(ancestorsExistIn(selectedItems) || selectedItems.contains(treeView.getRoot()));
         return deleteMenuItem;
     }
 
@@ -648,6 +650,20 @@ public class ProjectPane extends Tab {
                 }
             }
         });
+    }
+
+    private boolean ancestorsExistIn(List<? extends TreeItem<Object>> treeItems) {
+        boolean found = false;
+        for (TreeItem<Object> treeItem : treeItems) {
+            if (treeItem != treeView.getRoot()) {
+                AbstractNodeBase value = (AbstractNodeBase) treeItem.getValue();
+                found = treeItems.stream().filter(it -> it != treeItem).anyMatch(item -> ((AbstractNodeBase) item.getValue()).isAncestorOf(value));
+                if (found) {
+                    break;
+                }
+            }
+        }
+        return found;
     }
 
     private MenuItem createRenameProjectNodeItem(TreeItem selectedTreeItem) {


### PR DESCRIPTION
Deleting a parent node imply deleting all his child nodes so delete's MenuItem might be disabled when a child node and his parent are selected .
