### PR TITLE
Try to find substations and lines by name if not found by id

### DIFF
--- a/gse-network-map/src/main/java/com/powsybl/gse/map/NetworkMap.java
+++ b/gse-network-map/src/main/java/com/powsybl/gse/map/NetworkMap.java
@@ -125,6 +125,9 @@ public class NetworkMap extends StackPane implements ProjectFileViewer {
         Network network = projectCase.getNetwork();
         for (Substation substation : network.getSubstations()) {
             SubstationGraphic graphic = substations.get(substation.getId());
+            if (graphic == null && !substation.getId().equals(substation.getName())) {
+                graphic = substations.get(substation.getName());
+            }
             if (graphic != null) {
                 graphic.setModel(substation);
                 mappedSubstations++;
@@ -135,6 +138,9 @@ public class NetworkMap extends StackPane implements ProjectFileViewer {
         int mappedLines = 0;
         for (Line line : network.getLines()) {
             LineGraphic graphic = lines.get(line.getId());
+            if (graphic == null && !line.getId().equals(line.getName())) {
+                graphic = lines.get(line.getName());
+            }
             if (graphic != null) {
                 graphic.setModel(line);
                 mappedLines++;


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Mapping between IIDM network and GIS data is done using ID. In case of  CGMES data and RTE GIS data it is  necessary to use name instead of ID to look for coordinate. 


**What is the current behavior?** *(You can also link to an open issue here)*
No coordinate is found when mapping has to be done with name.


**What is the new behavior (if this is a feature change)?**
Coordinates are found when mapping has to be done with name.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*
No

**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
