### PR TITLE
Fix tab closing bug

### DIFF
--- a/gse-app/src/main/java/com/powsybl/gse/app/ProjectPane.java
+++ b/gse-app/src/main/java/com/powsybl/gse/app/ProjectPane.java
@@ -95,7 +95,21 @@ public class ProjectPane extends Tab {
         public MyTab(String text, ProjectFileViewer viewer) {
             super(text, viewer.getContent());
             this.viewer = viewer;
+            onKeyPressed();
             setContextMenu(contextMenu());
+        }
+
+        private void onKeyPressed() {
+            getContent().setOnKeyPressed((KeyEvent ke) -> {
+                if (closeKeyCombination.match(ke)) {
+                    closeTab(ke, this);
+                } else if (closeAllKeyCombination.match(ke)) {
+                    List<MyTab> mytabs = new ArrayList<>(getTabPane().getTabs().stream()
+                            .map(tab -> (MyTab) tab)
+                            .collect(Collectors.toList()));
+                    mytabs.forEach(mytab -> closeTab(ke, mytab));
+                }
+            });
         }
 
         private ContextMenu contextMenu() {
@@ -108,8 +122,6 @@ public class ProjectPane extends Tab {
                         .collect(Collectors.toList()));
                 mytabs.forEach(mytab -> closeTab(event, mytab));
             });
-            closeMenuItem.setAccelerator(closeKeyCombination);
-            closeAllMenuItem.setAccelerator(closeAllKeyCombination);
             return new ContextMenu(closeMenuItem, closeAllMenuItem);
         }
 

--- a/gse-app/src/main/java/com/powsybl/gse/app/ProjectPane.java
+++ b/gse-app/src/main/java/com/powsybl/gse/app/ProjectPane.java
@@ -103,11 +103,13 @@ public class ProjectPane extends Tab {
             getContent().setOnKeyPressed((KeyEvent ke) -> {
                 if (closeKeyCombination.match(ke)) {
                     closeTab(ke, this);
+                    ke.consume();
                 } else if (closeAllKeyCombination.match(ke)) {
                     List<MyTab> mytabs = new ArrayList<>(getTabPane().getTabs().stream()
                             .map(tab -> (MyTab) tab)
                             .collect(Collectors.toList()));
                     mytabs.forEach(mytab -> closeTab(ke, mytab));
+                    ke.consume();
                 }
             });
         }


### PR DESCRIPTION
Signed-off-by: NAMBIENA Nassirou <nassirou.nambiena@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
closing a tab with CTRL +W shortcut sometimes throws a NullPointerException 


**What is the new behavior (if this is a feature change)?**
Using a CTRL+W shortcut just close the current tab and only if the tab is selected



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*
no breaking change is identified

**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
