### PR TITLE
Fix tabulation's KeyCombination

### DIFF
--- a/gse-util/src/main/java/com/powsybl/gse/util/GroovyCodeEditor.java
+++ b/gse-util/src/main/java/com/powsybl/gse/util/GroovyCodeEditor.java
@@ -80,6 +80,8 @@ public class GroovyCodeEditor extends MasterDetailPane {
 
     private final KeyCombination pasteKeyCombination = new KeyCodeCombination(KeyCode.V, KeyCombination.CONTROL_DOWN);
 
+    private final KeyCombination tabKeyCombination = new KeyCodeCombination(KeyCode.TAB);
+
     private static final ServiceLoaderCache<KeywordsProvider> KEYWORDS_LOADER = new ServiceLoaderCache<>(KeywordsProvider.class);
 
     private static final ServiceLoaderCache<AutoCompletionWordsProvider> AUTO_COMPLETION_WORDS_LOADER = new ServiceLoaderCache<>(AutoCompletionWordsProvider.class);
@@ -363,7 +365,7 @@ public class GroovyCodeEditor extends MasterDetailPane {
     }
 
     private void setTabulationSpace(KeyEvent ke) {
-        if (ke.getCode() == KeyCode.TAB) {
+        if (tabKeyCombination.match(ke)) {
             ke.consume();
             int currentLine = codeArea.getCaretSelectionBind().getParagraphIndex();
             int fromLineStartToCaret = codeArea.getText(currentLine, 0, currentLine, codeArea.getCaretColumn()).length();


### PR DESCRIPTION
Signed-off-by: NAMBIENA Nassirou <nassirou.nambiena@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix



**What is the current behavior?** *(You can also link to an open issue here)*
the code editor confuses the key combination (CTRL + TAB) with the tab key  (Keycode.TAB) : the tab method is called when the key combination "CTRL + Tab" is typed.


**What is the new behavior (if this is a feature change)?**
the code editor makes the difference between  the key combination (CTRL + TAB) with the tab key  (Keycode.TAB) 

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*
No 

**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
