### PR TITLE
Hide the useless storages on NodeChooser

### DIFF
--- a/gse-afs-ext-base/src/main/java/com/powsybl/gse/afs/ext/base/BaseExtNodeGraphicProvider.java
+++ b/gse-afs-ext-base/src/main/java/com/powsybl/gse/afs/ext/base/BaseExtNodeGraphicProvider.java
@@ -27,13 +27,13 @@ public class BaseExtNodeGraphicProvider implements NodeGraphicProvider {
         Font.loadFont(Glyph.class.getResourceAsStream("/fonts/powsybl-gse-font.ttf"), 12);
     }
 
-    private static Glyph createIidmGlyph() {
+    public static Glyph createIidmGlyph() {
         return new Glyph("powsybl-gse-font", '\ue901')
                 .size("1.4em")
                 .color("orangered");
     }
 
-    private Node createCaseGlyph(Importer importer) {
+    public Node createCaseGlyph(Importer importer) {
         String format = importer.getFormat();
         if (format.equals("CIM1") || format.equals("CGMES")) {
             return new Glyph("powsybl-gse-font", '\ue900')
@@ -48,6 +48,17 @@ public class BaseExtNodeGraphicProvider implements NodeGraphicProvider {
         return null;
     }
 
+    public static Node createModificationScriptGlyph() {
+        return Glyph.createAwesomeFont('\uf0f6').size("1.2em");
+    }
+
+    public static Node createVirtualCaseGlyph() {
+        return createIidmGlyph()
+                .stack(Glyph.createAwesomeFont('\uf14b')
+                        .color("limegreen")
+                        .size("0.9em"));
+    }
+
     @Override
     public Node getGraphic(Object file) {
         if (file instanceof Case) {
@@ -57,12 +68,9 @@ public class BaseExtNodeGraphicProvider implements NodeGraphicProvider {
             ImportedCase importedCase = (ImportedCase) file;
             return createCaseGlyph(importedCase.getImporter());
         } else if (file instanceof VirtualCase) {
-            return createIidmGlyph()
-                    .stack(Glyph.createAwesomeFont('\uf14b')
-                                .color("limegreen")
-                                .size("0.9em"));
+            return createVirtualCaseGlyph();
         } else if (file instanceof ModificationScript) {
-            return Glyph.createAwesomeFont('\uf0f6').size("1.2em");
+            return createModificationScriptGlyph();
         }
         return null;
     }

--- a/gse-afs-ext-base/src/main/java/com/powsybl/gse/afs/ext/base/ContingencyStoreCreatorExtension.java
+++ b/gse-afs-ext-base/src/main/java/com/powsybl/gse/afs/ext/base/ContingencyStoreCreatorExtension.java
@@ -12,7 +12,7 @@ import com.powsybl.contingency.afs.ContingencyStore;
 import com.powsybl.gse.spi.GseContext;
 import com.powsybl.gse.spi.ProjectFileCreator;
 import com.powsybl.gse.spi.ProjectFileCreatorExtension;
-import com.powsybl.gse.util.Glyph;
+import com.powsybl.gse.util.NodeGraphics;
 import javafx.scene.Node;
 import javafx.scene.Scene;
 
@@ -33,7 +33,7 @@ public class ContingencyStoreCreatorExtension implements ProjectFileCreatorExten
 
     @Override
     public Node getMenuGraphic() {
-        return Glyph.createAwesomeFont('\uf016').size("1.2em");
+        return NodeGraphics.createFileGraphic();
     }
 
     @Override

--- a/gse-afs-ext-base/src/main/java/com/powsybl/gse/afs/ext/base/ImportedCaseCreatorExtension.java
+++ b/gse-afs-ext-base/src/main/java/com/powsybl/gse/afs/ext/base/ImportedCaseCreatorExtension.java
@@ -13,7 +13,6 @@ import com.powsybl.afs.ext.base.ImportedCase;
 import com.powsybl.gse.spi.GseContext;
 import com.powsybl.gse.spi.ProjectFileCreator;
 import com.powsybl.gse.spi.ProjectFileCreatorExtension;
-import com.powsybl.gse.util.Glyph;
 import javafx.scene.Node;
 import javafx.scene.Scene;
 
@@ -34,9 +33,7 @@ public class ImportedCaseCreatorExtension implements ProjectFileCreatorExtension
 
     @Override
     public Node getMenuGraphic() {
-        return new Glyph("powsybl-gse-font", '\ue901')
-                .size("1.4em")
-                .color("orangered");
+        return BaseExtNodeGraphicProvider.createIidmGlyph();
     }
 
     @Override

--- a/gse-afs-ext-base/src/main/java/com/powsybl/gse/afs/ext/base/ModificationScriptCreatorExtension.java
+++ b/gse-afs-ext-base/src/main/java/com/powsybl/gse/afs/ext/base/ModificationScriptCreatorExtension.java
@@ -12,7 +12,6 @@ import com.powsybl.afs.ext.base.ModificationScript;
 import com.powsybl.gse.spi.GseContext;
 import com.powsybl.gse.spi.ProjectFileCreator;
 import com.powsybl.gse.spi.ProjectFileCreatorExtension;
-import com.powsybl.gse.util.Glyph;
 import javafx.scene.Node;
 import javafx.scene.Scene;
 
@@ -33,7 +32,7 @@ public class ModificationScriptCreatorExtension implements ProjectFileCreatorExt
 
     @Override
     public Node getMenuGraphic() {
-        return Glyph.createAwesomeFont('\uf0f6').size("1.2em");
+        return BaseExtNodeGraphicProvider.createModificationScriptGlyph();
     }
 
     @Override

--- a/gse-afs-ext-base/src/main/java/com/powsybl/gse/afs/ext/base/ProjectCaseExportExtension.java
+++ b/gse-afs-ext-base/src/main/java/com/powsybl/gse/afs/ext/base/ProjectCaseExportExtension.java
@@ -17,6 +17,7 @@ import com.powsybl.gse.util.Glyph;
 import com.powsybl.iidm.xml.NetworkXml;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.value.ChangeListener;
 import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
@@ -26,6 +27,7 @@ import javafx.scene.control.TextField;
 import javafx.scene.layout.ColumnConstraints;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Priority;
+import javafx.scene.paint.Color;
 import javafx.stage.FileChooser;
 
 import java.io.*;
@@ -45,6 +47,8 @@ public class ProjectCaseExportExtension implements ProjectFileExecutionTaskExten
     private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle("lang.ProjectCaseExport");
 
     private final Preferences preferences = Preferences.userNodeForPackage(getClass());
+
+    private final Label fileAlreadyExistLabel = new Label();
 
     @Override
     public Class<ProjectFile> getProjectFileType() {
@@ -85,16 +89,19 @@ public class ProjectCaseExportExtension implements ProjectFileExecutionTaskExten
             {
                 main.setVgap(5);
                 main.setHgap(5);
-                main.setPrefWidth(400);
+                main.setPrefWidth(530);
                 ColumnConstraints column0 = new ColumnConstraints();
                 ColumnConstraints column1 = new ColumnConstraints();
                 column1.setHgrow(Priority.ALWAYS);
-                fileTextField.setText(projectCase.getName() + ".xiidm");
+                fileTextField.setText(projectCase.getName() + ProjectCaseExportParameters.XIIDM_EXT);
+                fileAlreadyExistLabel.setText("");
+                fileAlreadyExistLabel.setTextFill(Color.RED);
                 main.getColumnConstraints().addAll(column0, column1);
                 main.add(new Label(RESOURCE_BUNDLE.getString("DestinationFile") + ":"), 0, 0);
                 main.add(fileTextField, 1, 0);
                 main.add(fileButton, 2, 0);
                 main.add(zipCheckBox, 1, 1);
+                main.add(fileAlreadyExistLabel, 0, 2, 2, 1);
 
                 // Add action events
                 fileButton.setOnAction(event -> {
@@ -112,7 +119,7 @@ public class ProjectCaseExportExtension implements ProjectFileExecutionTaskExten
                 });
 
                 zipCheckBox.setSelected(config.isZipped());
-                zipCheckBox.setOnAction(event -> config.setZipped(zipCheckBox.isSelected()));
+                zipCheckBox.selectedProperty().addListener(zipCheckBoxSelectedPropertyListener(fileTextField, config, zipCheckBox, configProperty));
             }
 
             @Override
@@ -134,6 +141,35 @@ public class ProjectCaseExportExtension implements ProjectFileExecutionTaskExten
                 // nothing to dispose
             }
         };
+    }
+
+    private ChangeListener<Boolean> zipCheckBoxSelectedPropertyListener(TextField fileTextField, ProjectCaseExportParameters config, CheckBox zipCheckBox, ObjectProperty<ProjectCaseExportParameters> configProperty) {
+        return (observable, oldvalue, newvalue) -> {
+            String fileName = fileTextField.getText();
+            if (newvalue) {
+                if (fileName != null && !fileName.isEmpty() && !fileName.endsWith(ProjectCaseExportParameters.GZ_EXT)) {
+                    fileTextField.setText(fileName + ProjectCaseExportParameters.GZ_EXT);
+                }
+            } else {
+                if (fileName != null && !fileName.isEmpty() && fileName.endsWith(ProjectCaseExportParameters.GZ_EXT)) {
+                    fileTextField.setText(fileName.replace(ProjectCaseExportParameters.GZ_EXT, ""));
+                }
+            }
+            config.setZipped(zipCheckBox.isSelected());
+            displayFileExistsMessage(fileTextField, configProperty, config);
+        };
+    }
+
+    private void displayFileExistsMessage(TextField fileTextField, ObjectProperty<ProjectCaseExportParameters> configProperty, ProjectCaseExportParameters config) {
+        String text = fileTextField.getText();
+        if (new File(text).exists()) {
+            String fileNameWithExtension = text.substring(text.lastIndexOf('/') + 1);
+            configProperty.set(null);
+            fileAlreadyExistLabel.setText(MessageFormat.format(RESOURCE_BUNDLE.getString("FileAlreadyExistsInThisFolder"), fileNameWithExtension));
+        } else {
+            configProperty.set(config.getFilePathText() != null ? config : null);
+            fileAlreadyExistLabel.setText("");
+        }
     }
 
     private void openLastDirectory(FileChooser fileChooser) {

--- a/gse-afs-ext-base/src/main/java/com/powsybl/gse/afs/ext/base/ProjectCaseExportParameters.java
+++ b/gse-afs-ext-base/src/main/java/com/powsybl/gse/afs/ext/base/ProjectCaseExportParameters.java
@@ -14,8 +14,8 @@ import java.nio.file.Paths;
  */
 public class ProjectCaseExportParameters {
 
-    private static  final String XML_EXT = ".xml";
-    private static final String GZ_EXT = ".gz";
+    public static final String GZ_EXT = ".gz";
+    public static final String XIIDM_EXT = ".xiidm";
 
     private String filePath;
     private boolean zipped;
@@ -33,20 +33,14 @@ public class ProjectCaseExportParameters {
     }
 
     public Path getFilePath() {
-        if (zipped) {
-            if (!filePath.toLowerCase().endsWith(GZ_EXT)) {
-                if (!filePath.toLowerCase().endsWith(XML_EXT)) {
-                    filePath += XML_EXT + GZ_EXT;
-                } else {
-                    filePath += GZ_EXT;
-                }
-            }
-        } else {
-            if (!filePath.toLowerCase().endsWith(XML_EXT)) {
-                filePath += XML_EXT;
-            }
+        if (zipped && !filePath.toLowerCase().endsWith(GZ_EXT)) {
+            filePath += GZ_EXT;
         }
         return Paths.get(filePath);
+    }
+
+    public String getFilePathText() {
+        return filePath;
     }
 
     public void setFilePath(String filePath) {

--- a/gse-afs-ext-base/src/main/java/com/powsybl/gse/afs/ext/base/VirtualCaseCreatorExtension.java
+++ b/gse-afs-ext-base/src/main/java/com/powsybl/gse/afs/ext/base/VirtualCaseCreatorExtension.java
@@ -13,7 +13,6 @@ import com.powsybl.afs.ext.base.VirtualCase;
 import com.powsybl.gse.spi.GseContext;
 import com.powsybl.gse.spi.ProjectFileCreator;
 import com.powsybl.gse.spi.ProjectFileCreatorExtension;
-import com.powsybl.gse.util.Glyph;
 import javafx.scene.Node;
 import javafx.scene.Scene;
 
@@ -34,12 +33,7 @@ public class VirtualCaseCreatorExtension implements ProjectFileCreatorExtension 
 
     @Override
     public Node getMenuGraphic() {
-        return new Glyph("powsybl-gse-font", '\ue901')
-                .size("1.4em")
-                .color("orangered")
-                .stack(Glyph.createAwesomeFont('\uf14b')
-                .color("limegreen")
-                .size("0.9em"));
+        return BaseExtNodeGraphicProvider.createVirtualCaseGlyph();
     }
 
     @Override

--- a/gse-afs-ext-base/src/main/resources/lang/ProjectCaseExport.properties
+++ b/gse-afs-ext-base/src/main/resources/lang/ProjectCaseExport.properties
@@ -1,6 +1,7 @@
-CaseExportParameters=Case export parameters
-DestinationFile=Destination file
-CompressedFile=Compressed file
-SelectTargetFile=Select target file
 CaseExport=Export
+CaseExportParameters=Case export parameters
+CompressedFile=Compressed file
+DestinationFile=Destination file
 ExportCaseToIIDM=Export case to {0}
+FileAlreadyExistsInThisFolder=A file named {0} already exists in this folder
+SelectTargetFile=Select target file

--- a/gse-afs-ext-base/src/main/resources/lang/ProjectCaseExport_fr.properties
+++ b/gse-afs-ext-base/src/main/resources/lang/ProjectCaseExport_fr.properties
@@ -1,6 +1,7 @@
-CaseExportParameters=Configuration de l'export de la situation
-DestinationFile=Fichier de destination
-CompressedFile=Format compressé
-SelectTargetFile=Choix du fichier
 CaseExport=Exporter
+CaseExportParameters=Configuration de l'export de la situation
+CompressedFile=Format compressé
+DestinationFile=Fichier de destination
 ExportCaseToIIDM=Export case to {0}
+FileAlreadyExistsInThisFolder=Un fichier nommé {0} existe déjà dans ce dossier
+SelectTargetFile=Choix du fichier

--- a/gse-app/src/main/java/com/powsybl/gse/app/ProjectPane.java
+++ b/gse-app/src/main/java/com/powsybl/gse/app/ProjectPane.java
@@ -95,7 +95,23 @@ public class ProjectPane extends Tab {
         public MyTab(String text, ProjectFileViewer viewer) {
             super(text, viewer.getContent());
             this.viewer = viewer;
+            onKeyPressed();
             setContextMenu(contextMenu());
+        }
+
+        private void onKeyPressed() {
+            getContent().setOnKeyPressed((KeyEvent ke) -> {
+                if (closeKeyCombination.match(ke)) {
+                    closeTab(ke, this);
+                    ke.consume();
+                } else if (closeAllKeyCombination.match(ke)) {
+                    List<MyTab> mytabs = new ArrayList<>(getTabPane().getTabs().stream()
+                            .map(tab -> (MyTab) tab)
+                            .collect(Collectors.toList()));
+                    mytabs.forEach(mytab -> closeTab(ke, mytab));
+                    ke.consume();
+                }
+            });
         }
 
         private ContextMenu contextMenu() {
@@ -108,8 +124,6 @@ public class ProjectPane extends Tab {
                         .collect(Collectors.toList()));
                 mytabs.forEach(mytab -> closeTab(event, mytab));
             });
-            closeMenuItem.setAccelerator(closeKeyCombination);
-            closeAllMenuItem.setAccelerator(closeAllKeyCombination);
             return new ContextMenu(closeMenuItem, closeAllMenuItem);
         }
 

--- a/gse-demo/pom.xml
+++ b/gse-demo/pom.xml
@@ -23,6 +23,39 @@
     <description>A demonstration module of GSE</description>
 
     <profiles>
+      <profile>
+          <id>windows</id>
+          <activation>
+            <os>
+              <family>windows</family>
+            </os>
+          </activation>
+          <properties>
+            <javafx.bundler>windows.app</javafx.bundler>
+          </properties>
+        </profile>
+        <profile>
+          <id>mac</id>
+          <activation>
+            <os>
+              <family>mac</family>
+            </os>
+          </activation>
+          <properties>
+            <javafx.bundler>mac.app</javafx.bundler>
+          </properties>
+        </profile>
+        <profile>
+          <id>unix</id>
+          <activation>
+            <os>
+              <family>unix</family>
+            </os>
+          </activation>
+          <properties>
+            <javafx.bundler>linux.app</javafx.bundler>
+          </properties>
+        </profile>
         <profile>
             <id>native-package</id>
             <activation>
@@ -71,6 +104,7 @@
                                 <powsybl.config.dirs>${user_home}/.powsybl:${app.root}/app</powsybl.config.dirs>
                                 <javafx.preloader>com.powsybl.gse.app.GsePreloader</javafx.preloader>
                             </jvmProperties>
+                            <bundler>${javafx.bundler}</bundler>
                         </configuration>
                         <executions>
                             <execution>

--- a/gse-demo/pom.xml
+++ b/gse-demo/pom.xml
@@ -143,6 +143,11 @@
         </dependency>
 
         <!-- Runtime dependencies -->
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-config-classic</artifactId>
+            <scope>runtime</scope>
+        </dependency>
 
         <!-- logging -->
         <dependency>

--- a/gse-demo/src/main/java/com/powsybl/gse/demo/GseDemo.java
+++ b/gse-demo/src/main/java/com/powsybl/gse/demo/GseDemo.java
@@ -9,18 +9,156 @@ package com.powsybl.gse.demo;
 import com.powsybl.gse.app.GseApp;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import javax.swing.JOptionPane;
+import javax.swing.JTextArea;
+
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
+// This class deals with very low level errors so let's suppress warnings
+@SuppressWarnings("all")
 public final class GseDemo {
+
+    private static final String UNCAUGHT_EXCEPTION_MESSAGE = "FATAL: uncaught throwable in javafx startup";
+    private static final String STARTUP_ERROR_LOGFILE_NAME = "GSE_STARTUP_ERROR";
 
     private GseDemo() {
     }
 
-    public static void main(String[] args) {
-        SLF4JBridgeHandler.removeHandlersForRootLogger();
-        SLF4JBridgeHandler.install();
+    private static void safeFileDump(Throwable t, String filename) {
+        try (PrintStream ps = new PrintStream(filename)) {
+            safeDump(t, ps);
+        } catch (Throwable ignored) {
+            // Swallow the throwable here, we don't want to confuse the user.
+            // This is such a broken case that we don't want to
+            // log the throwable, we want the other mechanisms in this method
+            // to log the rootThrowable to fix the root cause.
+            t.addSuppressed(ignored);
+        }
+    }
 
-        GseApp.main(args);
+    private static void safeDump(Throwable t, PrintStream ps) {
+        try {
+            ps.println(UNCAUGHT_EXCEPTION_MESSAGE);
+            t.printStackTrace(ps);
+        } catch (Throwable ignored) {
+            // Swallow the throwable here, we don't want to confuse the user.
+            // This is such a broken case that we don't want to
+            // log the throwable, we want the other mechanisms in this method
+            // to log the rootThrowable to fix the root cause.
+            t.addSuppressed(ignored);
+        }
+    }
+
+    // The system is utterly broken. Try as many things as we can to get some info
+    // to the user. This method creates a new file each time it is called, so don't
+    // call
+    // it multiple times.
+    private static void lastResortFallbackErrorLog(Throwable t) {
+        // We don't even have a logging system, this happens for example
+        // if we are missing jars or if the magic javalauncher has a problem.
+        // Try to show the error everywhere so that the user has the best chance of
+        // noticing it...
+
+        // Try stdout
+        safeDump(t, System.out);
+
+        String nonce = "-" + System.currentTimeMillis() + ".log";
+        // Try a file in the app directory, next to powsybl.log
+        safeFileDump(t, STARTUP_ERROR_LOGFILE_NAME + nonce);
+        // Try a file in the root directory, next to the executable
+        safeFileDump(t, "../" + STARTUP_ERROR_LOGFILE_NAME + nonce);
+    }
+
+    private static void showEmergencyPopup(Throwable t) {
+        StringWriter sw = new StringWriter();
+        try (PrintWriter pw = new PrintWriter(sw)) {
+            t.printStackTrace(pw);
+        }
+        String stackTrace = sw.toString();
+        Object message;
+        try {
+            JTextArea textarea = new JTextArea(stackTrace);
+            textarea.setEditable(false);
+            message = textarea;
+        } catch (Throwable jTextAreaThrowable) {
+            // Even the venerable JTextArea can fail.. In this case, pass
+            // the string (in java 8 it is rendered by a JLabel, which may still work).
+            message = stackTrace;
+            t.addSuppressed(jTextAreaThrowable);
+        }
+        JOptionPane.showMessageDialog(null, message, UNCAUGHT_EXCEPTION_MESSAGE, JOptionPane.ERROR_MESSAGE);
+    }
+
+    private static void logThrowable(Throwable rootThrowable, Logger logger) {
+        if (logger != null) {
+            try {
+                logger.error(UNCAUGHT_EXCEPTION_MESSAGE, rootThrowable);
+            } catch (Throwable slf4jThrowable) {
+                rootThrowable.addSuppressed(slf4jThrowable);
+                // Swallow slf4jThrowable here, we don't want to confuse the user
+                // This is such a broken case that we don't want to
+                // log slf4jThrowable to fix slf4j, we want to log rootThrowable to fix the root
+                // cause.
+                lastResortFallbackErrorLog(rootThrowable);
+            }
+        } else {
+            lastResortFallbackErrorLog(rootThrowable);
+        }
+    }
+
+    // Using javapackager from jdk8,
+    // we must avoid throwing an exception at all costs because
+    // the javapackager launcher just prints an InvocationException
+    // message on stdout. This is the message you get, it has no information:
+    // GseDemo Error invoking method.
+    // GseDemo Failed to launch JVM
+    //
+    // Also stdout is not always available, most notably when a user
+    // launches the application by double clicking in a file explorer
+    public static void main(String[] args) {
+        // Don't use a static logger so that this method can run
+        // even if there is a problem loading the logger classes
+        Logger logger = null;
+        try {
+            // Get a logger before everything, because of two reasons:
+            // 1) we may need it if the SLF4JBridgeHandler throws
+            // 2) if a call to getLogger fails (inside GseApp.main), the next call to
+            // getLogger does *not* throw an exception and instead returns a noop logger
+            // which leads to swallowing the exception
+            logger = LoggerFactory.getLogger(GseDemo.class);
+
+            SLF4JBridgeHandler.removeHandlersForRootLogger();
+            SLF4JBridgeHandler.install();
+
+            GseApp.main(args);
+        } catch (Throwable rootThrowable) {
+            try {
+                try {
+                    logThrowable(rootThrowable, logger);
+                } catch (Throwable ignored) {
+                    rootThrowable.addSuppressed(ignored);
+                }
+                try {
+                    showEmergencyPopup(rootThrowable);
+                } catch (Throwable ignored) {
+                    rootThrowable.addSuppressed(ignored);
+                }
+            } finally {
+                // We always rethrow the original exception to let the java launcher do
+                // something we it.
+                // With javapackager from jdk8, this displays somewhat useless message on stdout
+                // and exits with code 1.
+                // On windows this opens a popup displaying the error messages.
+                throw rootThrowable;
+            }
+        }
     }
 }

--- a/gse-security-analysis/src/main/java/com/powsybl/gse/security/SecurityAnalysisNodeGraphicProvider.java
+++ b/gse-security-analysis/src/main/java/com/powsybl/gse/security/SecurityAnalysisNodeGraphicProvider.java
@@ -20,6 +20,12 @@ import javafx.scene.Node;
 @AutoService(NodeGraphicProvider.class)
 public class SecurityAnalysisNodeGraphicProvider implements NodeGraphicProvider {
 
+    public static Node createSecurityAnalysisRunnerGlyph() {
+        return Glyph.createAwesomeFont('\uf132')
+                .size("1.4em")
+                .color("dimgray");
+    }
+
     @Override
     public Node getGraphic(Object file) {
         if (file instanceof ActionScript) {
@@ -30,9 +36,7 @@ public class SecurityAnalysisNodeGraphicProvider implements NodeGraphicProvider 
                     .size("1.4em")
                     .color("orange");
         } else if (file instanceof SecurityAnalysisRunner) {
-            return Glyph.createAwesomeFont('\uf132')
-                    .size("1.4em")
-                    .color("dimgray");
+            return createSecurityAnalysisRunnerGlyph();
         }
         return null;
     }

--- a/gse-security-analysis/src/main/java/com/powsybl/gse/security/SecurityAnalysisRunnerCreatorExtension.java
+++ b/gse-security-analysis/src/main/java/com/powsybl/gse/security/SecurityAnalysisRunnerCreatorExtension.java
@@ -11,6 +11,7 @@ import com.powsybl.afs.ProjectFolder;
 import com.powsybl.gse.spi.GseContext;
 import com.powsybl.gse.spi.ProjectFileCreatorExtension;
 import com.powsybl.security.afs.SecurityAnalysisRunner;
+import javafx.scene.Node;
 import javafx.scene.Scene;
 
 import java.util.ResourceBundle;
@@ -26,6 +27,11 @@ public class SecurityAnalysisRunnerCreatorExtension implements ProjectFileCreato
     @Override
     public Class<SecurityAnalysisRunner> getProjectFileType() {
         return SecurityAnalysisRunner.class;
+    }
+
+    @Override
+    public Node getMenuGraphic() {
+        return SecurityAnalysisNodeGraphicProvider.createSecurityAnalysisRunnerGlyph();
     }
 
     @Override

--- a/gse-util/src/main/java/com/powsybl/gse/util/GroovyCodeEditor.java
+++ b/gse-util/src/main/java/com/powsybl/gse/util/GroovyCodeEditor.java
@@ -80,6 +80,8 @@ public class GroovyCodeEditor extends MasterDetailPane {
 
     private final KeyCombination pasteKeyCombination = new KeyCodeCombination(KeyCode.V, KeyCombination.CONTROL_DOWN);
 
+    private final KeyCombination tabKeyCombination = new KeyCodeCombination(KeyCode.TAB);
+
     private static final ServiceLoaderCache<KeywordsProvider> KEYWORDS_LOADER = new ServiceLoaderCache<>(KeywordsProvider.class);
 
     private static final ServiceLoaderCache<AutoCompletionWordsProvider> AUTO_COMPLETION_WORDS_LOADER = new ServiceLoaderCache<>(AutoCompletionWordsProvider.class);
@@ -363,7 +365,7 @@ public class GroovyCodeEditor extends MasterDetailPane {
     }
 
     private void setTabulationSpace(KeyEvent ke) {
-        if (ke.getCode() == KeyCode.TAB) {
+        if (tabKeyCombination.match(ke)) {
             ke.consume();
             int currentLine = codeArea.getCaretSelectionBind().getParagraphIndex();
             int fromLineStartToCaret = codeArea.getText(currentLine, 0, currentLine, codeArea.getCaretColumn()).length();

--- a/gse-util/src/main/java/com/powsybl/gse/util/NodeChooser.java
+++ b/gse-util/src/main/java/com/powsybl/gse/util/NodeChooser.java
@@ -48,7 +48,7 @@ public class NodeChooser<N, F extends N, D extends N, T extends N> extends GridP
     private enum NodeChooserView {
         ALL_STORAGES,
         LOCAL_STORAGE_ONLY,
-        PROJECTS_STOTAGE_ONLY
+        PROJECTS_STORAGE_ONLY
     }
 
     public interface TreeModel<N, F, D> {
@@ -368,7 +368,7 @@ public class NodeChooser<N, F extends N, D extends N, T extends N> extends GridP
     }
 
     private void setNodeChooserView(NodeChooserView nodeChooserView, TreeItem<N> node) {
-        if (nodeChooserView == NodeChooserView.PROJECTS_STOTAGE_ONLY) {
+        if (nodeChooserView == NodeChooserView.PROJECTS_STORAGE_ONLY) {
             if (node.getValue() instanceof Folder && ((Folder) node.getValue()).isWritable()) {
                 node.setExpanded(true);
             }
@@ -789,7 +789,7 @@ public class NodeChooser<N, F extends N, D extends N, T extends N> extends GridP
 
     public static <T extends Node> Optional<T> showAndWaitDialog(Window window, AppData appData, GseContext context,
                                                                  BiPredicate<Node, TreeModel<Node, File, Folder>> filter) {
-        return showAndWaitDialog(new TreeModelImpl(appData), window, appData, context, filter,  NodeChooserView.PROJECTS_STOTAGE_ONLY);
+        return showAndWaitDialog(new TreeModelImpl(appData), window, appData, context, filter,  NodeChooserView.PROJECTS_STORAGE_ONLY);
     }
 
     private static <N, T extends N> boolean testNode(N node, Class<T> filter, Class<?>... otherFilters) {
@@ -809,7 +809,7 @@ public class NodeChooser<N, F extends N, D extends N, T extends N> extends GridP
     }
 
     public static <T extends Node> Optional<T> showAndWaitDialog(Window window, AppData appData, GseContext context, Class<T> filter, Set<String> openedProjectsList, Class<?>... otherFilters) {
-        return showAndWaitDialog(new TreeModelImpl(appData), window, appData, context, (node, treeModel) -> testNode(node, filter, otherFilters), NodeChooserView.PROJECTS_STOTAGE_ONLY, openedProjectsList);
+        return showAndWaitDialog(new TreeModelImpl(appData), window, appData, context, (node, treeModel) -> testNode(node, filter, otherFilters), NodeChooserView.PROJECTS_STORAGE_ONLY, openedProjectsList);
     }
 
     public static <T extends ProjectNode> Optional<T> showAndWaitDialog(Project project, Window window, GseContext context, BiPredicate<ProjectNode, TreeModel<ProjectNode, ProjectFile, ProjectFolder>> filter) {

--- a/gse-util/src/main/java/com/powsybl/gse/util/NodeGraphics.java
+++ b/gse-util/src/main/java/com/powsybl/gse/util/NodeGraphics.java
@@ -24,7 +24,7 @@ public final class NodeGraphics {
     private NodeGraphics() {
     }
 
-    private static Text createFileGraphic() {
+    public static Text createFileGraphic() {
         return Glyph.createAwesomeFont('\uf016').size("1.2em");
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -492,6 +492,12 @@
             </dependency>
             <dependency>
                 <groupId>com.powsybl</groupId>
+                <artifactId>powsybl-config-classic</artifactId>
+                <version>${powsyblcore.version}</version>
+                <scope>runtime</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.powsybl</groupId>
                 <artifactId>powsybl-iidm-impl</artifactId>
                 <version>${powsyblcore.version}</version>
                 <scope>runtime</scope>


### PR DESCRIPTION
Signed-off-by: NAMBIENA Nassirou <nassirou.nambiena@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
the node chooser pane displays all storages 


**What is the new behavior (if this is a feature change)?**
the node chooser pane displays only concerned storages


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*
no breaking change

**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
