### PR TITLE
gse-demo: only generate the app image (reduces the build time by a fe…

### DIFF
--- a/gse-demo/pom.xml
+++ b/gse-demo/pom.xml
@@ -23,6 +23,39 @@
     <description>A demonstration module of GSE</description>
 
     <profiles>
+      <profile>
+          <id>windows</id>
+          <activation>
+            <os>
+              <family>windows</family>
+            </os>
+          </activation>
+          <properties>
+            <javafx.bundler>windows.app</javafx.bundler>
+          </properties>
+        </profile>
+        <profile>
+          <id>mac</id>
+          <activation>
+            <os>
+              <family>mac</family>
+            </os>
+          </activation>
+          <properties>
+            <javafx.bundler>mac.app</javafx.bundler>
+          </properties>
+        </profile>
+        <profile>
+          <id>unix</id>
+          <activation>
+            <os>
+              <family>unix</family>
+            </os>
+          </activation>
+          <properties>
+            <javafx.bundler>linux.app</javafx.bundler>
+          </properties>
+        </profile>
         <profile>
             <id>native-package</id>
             <activation>
@@ -71,6 +104,7 @@
                                 <powsybl.config.dirs>${user_home}/.powsybl:${app.root}/app</powsybl.config.dirs>
                                 <javafx.preloader>com.powsybl.gse.app.GsePreloader</javafx.preloader>
                             </jvmProperties>
+                            <bundler>${javafx.bundler}</bundler>
                         </configuration>
                         <executions>
                             <execution>


### PR DESCRIPTION
…w minutes)

Signed-off-by: Jon Harper <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
On linux, building takes about a minute on the deb/rpm phase, which we don't want. I haven't tested with bundlers of other platforms. We don't even want this, we want the app image.


**What is the current behavior?** *(You can also link to an open issue here)*
Takes a long time to generate unused installers (rpm for example)


**What is the new behavior (if this is a feature change)?**
Don't generate the installers. The app image (the root app folder) is still generated like before.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*
NO

**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
