### PR TITLE
Add security analysis Menu's graphic

### DIFF
--- a/gse-security-analysis/src/main/java/com/powsybl/gse/security/SecurityAnalysisRunnerCreatorExtension.java
+++ b/gse-security-analysis/src/main/java/com/powsybl/gse/security/SecurityAnalysisRunnerCreatorExtension.java
@@ -10,7 +10,9 @@ import com.google.auto.service.AutoService;
 import com.powsybl.afs.ProjectFolder;
 import com.powsybl.gse.spi.GseContext;
 import com.powsybl.gse.spi.ProjectFileCreatorExtension;
+import com.powsybl.gse.util.Glyph;
 import com.powsybl.security.afs.SecurityAnalysisRunner;
+import javafx.scene.Node;
 import javafx.scene.Scene;
 
 import java.util.ResourceBundle;
@@ -22,6 +24,13 @@ import java.util.ResourceBundle;
 public class SecurityAnalysisRunnerCreatorExtension implements ProjectFileCreatorExtension {
 
     private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle("lang.SecurityAnalysis");
+
+    @Override
+    public Node getMenuGraphic() {
+        return Glyph.createAwesomeFont('\uf132')
+                .size("1.4em")
+                .color("dimgray");
+    }
 
     @Override
     public Class<SecurityAnalysisRunner> getProjectFileType() {


### PR DESCRIPTION
Signed-off-by: NAMBIENA Nassirou Ext <nassirou.nambiena@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
there is a missing graphic for Security Analaysis creating Menu item


**What is the new behavior (if this is a feature change)?**
A defauflt graphic is added on the context menu for Security analysis runner creation


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*
No breaking change

**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
