### PR TITLE
GseDemo: use ClassicPlatformConfigProvider to fix deployment

### DIFF
--- a/gse-demo/pom.xml
+++ b/gse-demo/pom.xml
@@ -143,6 +143,11 @@
         </dependency>
 
         <!-- Runtime dependencies -->
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-config-classic</artifactId>
+            <scope>runtime</scope>
+        </dependency>
 
         <!-- logging -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -492,6 +492,12 @@
             </dependency>
             <dependency>
                 <groupId>com.powsybl</groupId>
+                <artifactId>powsybl-config-classic</artifactId>
+                <version>${powsyblcore.version}</version>
+                <scope>runtime</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.powsybl</groupId>
                 <artifactId>powsybl-iidm-impl</artifactId>
                 <version>${powsyblcore.version}</version>
                 <scope>runtime</scope>


### PR DESCRIPTION
Signed-off-by: Jon Harper <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Compatibility with powsybl 3.0.0 config


**What is the current behavior?** *(You can also link to an open issue here)*
Exception DefaultPlatformConfig Not Found on gse demo startup


**What is the new behavior (if this is a feature change)?**
No exceptions


NO

**Other information**:
To merge when powsybl-config-classic is merged in powsybl-core