### PR TITLE
Remove tree view selection on project pane loosing focus

### DIFF
--- a/gse-app/src/main/java/com/powsybl/gse/app/ProjectPane.java
+++ b/gse-app/src/main/java/com/powsybl/gse/app/ProjectPane.java
@@ -450,6 +450,11 @@ public class ProjectPane extends Tab {
         treeView.getSelectionModel().getSelectedItems().addListener(this::treeViewChangeListener);
         treeView.setCellFactory(this::treeViewCellFactory);
         treeView.setOnMouseClicked(this::treeViewMouseClickHandler);
+        treeView.focusedProperty().addListener((observable, oldValue, newValue) -> {
+            if (!newValue) {
+                treeView.getSelectionModel().clearSelection();
+            }
+        });
 
         DetachableTabPane ctrlTabPane1 = new DetachableTabPane();
         DetachableTabPane ctrlTabPane2 = new DetachableTabPane();


### PR DESCRIPTION
Signed-off-by: Paul Bui-Quang <paul.buiquang@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
the project pane treeview item maintain selection even when loosing focus, this entails that shortcuts are enabled when they shouldn't. eg. The delete key on the editor pane will ask for treeview item deletion.


**What is the new behavior (if this is a feature change)?**
treeview selection is cleared on focus loss

