### PR TITLE
gse-demo: add user-agent to play nice with openstreetmap tiles

### DIFF
--- a/gse-demo/pom.xml
+++ b/gse-demo/pom.xml
@@ -101,6 +101,7 @@
                             <skipJNLP>true</skipJNLP>
                             <jvmProperties>
                                 <app.root>$APPDIR</app.root>
+                                <http.agent>Powsybl-Gse</http.agent>
                                 <powsybl.config.dirs>${user_home}/.powsybl:${app.root}/app</powsybl.config.dirs>
                                 <javafx.preloader>com.powsybl.gse.app.GsePreloader</javafx.preloader>
                             </jvmProperties>


### PR DESCRIPTION
Signed-off-by: Jon Harper <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug Fix


**What is the current behavior?** *(You can also link to an open issue here)*
The openstreetmap tiles don't load


**What is the new behavior (if this is a feature change)?**
The openstreetmap tiles load


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*
NO

**Other information**:
The same patch is applied upstream in 2.0.0-ea+2