### PR TITLE
Add flag to prioritize writable display in node chooser

### DIFF
--- a/gse-app/src/main/java/com/powsybl/gse/app/GsePane.java
+++ b/gse-app/src/main/java/com/powsybl/gse/app/GsePane.java
@@ -109,7 +109,7 @@ public class GsePane extends StackPane {
         for (Tab tab : tabPane.getTabs()) {
             openedProjects.add(((ProjectPane) tab).getProject().getId());
         }
-        Optional<Project> project = NodeChooser.showAndWaitDialog(getScene().getWindow(), data, context, Project.class, openedProjects);
+        Optional<Project> project = NodeChooser.showAndWaitDialog(getScene().getWindow(), data, context, true, Project.class, openedProjects);
         project.ifPresent(this::openProject);
     }
 

--- a/gse-app/src/main/java/com/powsybl/gse/app/NewProjectPane.java
+++ b/gse-app/src/main/java/com/powsybl/gse/app/NewProjectPane.java
@@ -60,7 +60,7 @@ public class NewProjectPane extends GridPane {
 
     public NewProjectPane(Window window, AppData appData, GseContext context) {
         folderSelectionButton.setOnAction(event -> {
-            Optional<Folder> folder = NodeChooser.showAndWaitDialog(window, appData, context,
+            Optional<Folder> folder = NodeChooser.showAndWaitDialog(window, appData, context, true,
                 (node, treeModel) -> Folder.class.isAssignableFrom(node.getClass()) && ((Folder) node).isWritable());
             folder.ifPresent(folderProperty::setValue);
         });

--- a/gse-util/src/main/java/com/powsybl/gse/util/NodeChooser.java
+++ b/gse-util/src/main/java/com/powsybl/gse/util/NodeChooser.java
@@ -343,18 +343,16 @@ public class NodeChooser<N, F extends N, D extends N, T extends N> extends GridP
         add(scrollPane, 0, 1, 2, 1);
         context.getExecutor().submit(() -> {
             try {
-                List<TreeItem<N>> nodes = treeModel
-                        .getRootFolders()
-                        .stream()
-                        .map(rootFolder -> {
-                            TreeItem<N> node = createCollapsedFolderItem(rootFolder);
-                            if (writableFsDisplayPriority == null || writableFsDisplayPriority == treeModel.isWritable(rootFolder)) {
-                                node.setExpanded(true);
-                            }
-                            return node;
-                        })
-                        .sorted(Comparator.comparing(item -> !item.isExpanded()))
-                        .collect(Collectors.toList());
+                List<TreeItem<N>> nodes = new ArrayList<>();
+                for (D rootFolder : treeModel.getRootFolders()) {
+                    TreeItem<N> node = createCollapsedFolderItem(rootFolder);
+                    if (writableFsDisplayPriority == null || writableFsDisplayPriority == treeModel.isWritable(rootFolder)) {
+                        node.setExpanded(true);
+                    }
+                    nodes.add(node);
+                }
+                Collections.sort(nodes, Comparator.comparing(item -> !item.isExpanded()));
+
                 Platform.runLater(() -> {
                     rootItem.getChildren().setAll(nodes);
                     // select first root

--- a/gse-util/src/main/java/com/powsybl/gse/util/NodeSelectionPane.java
+++ b/gse-util/src/main/java/com/powsybl/gse/util/NodeSelectionPane.java
@@ -21,7 +21,7 @@ public class NodeSelectionPane<T extends Node> extends AbstractNodeSelectionPane
     }
 
     public NodeSelectionPane(AppData data, String label, boolean mandatory, Window window, GseContext context, Class<T> filter, Class<?>... otherFilters) {
-        super(label, () -> NodeChooser.showAndWaitDialog(window, data, context, filter, otherFilters), mandatory, context);
+        super(label, () -> NodeChooser.showAndWaitDialog(window, data, context, false, filter, otherFilters), mandatory, context);
     }
 }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature


**What is the current behavior?** *(You can also link to an open issue here)*
NodeChooser display all available filesystems in expanded mode. This is not user friendly when the user has a lot of network drives and want only to see a specific kind of fs (those being usually writable)


**What is the new behavior (if this is a feature change)?**
Add a flag to sort and expand writable or non writable filesystem.

