### PR TITLE
Rename real child node with name conflict

### DIFF
--- a/gse-copy-paste-afs/src/main/java/com/powsybl/gse/copy_paste/afs/CopyManager.java
+++ b/gse-copy-paste-afs/src/main/java/com/powsybl/gse/copy_paste/afs/CopyManager.java
@@ -255,7 +255,7 @@ public final class CopyManager {
         String copyNameBaseName = name + copyDuplicated;
         AtomicReference<String> copyName = new AtomicReference<>(copyNameBaseName);
         try {
-            info.node.rename(name + UUID.randomUUID().toString());
+            child.rename(name + UUID.randomUUID().toString());
             projectFolder.unarchive(info.archivePath.resolve(info.nodeId));
 
             projectFolder.getChild(name).ifPresent(newNode -> {
@@ -279,7 +279,7 @@ public final class CopyManager {
             });
 
         } finally {
-            info.node.rename(name);
+            child.rename(name);
         }
 
         return copyName.get();


### PR DESCRIPTION
Signed-off-by: Paul Bui-Quang <paul.buiquang@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
On pasting a node into an other folder containing a node with the same name, the renaming system was renaming the original node, not the node with name conflict in paste target directory


**What is the new behavior (if this is a feature change)?**
The correct node is renamed

