### PR TITLE
Readd modificationdate column + add metadata tooltip

### DIFF
--- a/gse-app/src/main/java/com/powsybl/gse/app/ProjectPane.java
+++ b/gse-app/src/main/java/com/powsybl/gse/app/ProjectPane.java
@@ -66,6 +66,7 @@ public class ProjectPane extends Tab {
     private static final ServiceLoaderCache<ProjectFileCreatorExtension> CREATOR_EXTENSION_LOADER = new ServiceLoaderCache<>(ProjectFileCreatorExtension.class);
     private static final ServiceLoaderCache<ProjectFileEditorExtension> EDITOR_EXTENSION_LOADER = new ServiceLoaderCache<>(ProjectFileEditorExtension.class);
     private static final ServiceLoaderCache<ProjectFileViewerExtension> VIEWER_EXTENSION_LOADER = new ServiceLoaderCache<>(ProjectFileViewerExtension.class);
+    private static final ServiceLoaderCache<ProjectFileMetadataViewerExtension> METADATA_VIEWER_EXTENSION_LOADER = new ServiceLoaderCache<>(ProjectFileMetadataViewerExtension.class);
     private static final ServiceLoaderCache<ProjectFileExecutionTaskExtension> EXECUTION_TASK_EXTENSION_LOADER = new ServiceLoaderCache<>(ProjectFileExecutionTaskExtension.class);
     private static final List<ProjectFileExtension> PROJECT_FILE_EXTENSIONS = new ServiceLoaderCache<>(ProjectFileExtension.class).getServices();
 
@@ -214,6 +215,14 @@ public class ProjectPane extends Tab {
                                 ProjectNode node = (ProjectNode) item;
                                 if (node instanceof ProjectFile) {
                                     setTextFill(getProjectFileColor((ProjectFile) node));
+                                }
+                                if (item instanceof ProjectFile) {
+                                    ProjectFile projectFile = (ProjectFile) item;
+                                    List<ProjectFileMetadataViewerExtension> metadataViewerExtensions = findMetadataViewerExtensions(projectFile);
+                                    metadataViewerExtensions.stream().findFirst().ifPresent(extension -> {
+                                        Tooltip tooltip = new Tooltip(extension.display(projectFile));
+                                        setTooltip(tooltip);
+                                    });
                                 }
                                 setText(node.getName());
                                 setGraphic(NodeGraphics.getGraphic(item));
@@ -595,6 +604,12 @@ public class ProjectPane extends Tab {
         return EDITOR_EXTENSION_LOADER.getServices().stream()
                 .filter(extension -> extension.getProjectFileType().isAssignableFrom(file.getClass())
                         && (extension.getAdditionalType() == null || extension.getAdditionalType().isAssignableFrom(file.getClass())))
+                .collect(Collectors.toList());
+    }
+
+    public static List<ProjectFileMetadataViewerExtension> findMetadataViewerExtensions(ProjectFile file) {
+        return METADATA_VIEWER_EXTENSION_LOADER.getServices().stream()
+                .filter(extension -> extension.getProjectFileType().isAssignableFrom(file.getClass()))
                 .collect(Collectors.toList());
     }
 

--- a/gse-app/src/main/java/com/powsybl/gse/app/ProjectPane.java
+++ b/gse-app/src/main/java/com/powsybl/gse/app/ProjectPane.java
@@ -250,13 +250,13 @@ public class ProjectPane extends Tab {
                         setText(null);
                         setGraphic(null);
                     } else {
-                        setText(item.format(DateTimeFormatter.ofPattern("d MMM yy, HH:mm")));
+                        setText(item.format(DateTimeFormatter.ofPattern("dd/MM/yy, HH:mm")));
                     }
                 }
             };
         });
         treeTableView.getColumns().add(nameColumn);
-//        treeTableView.getColumns().add(dateColumn);
+        treeTableView.getColumns().add(dateColumn);
         treeTableView.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
         treeTableView.getSelectionModel().getSelectedItems().addListener(this::treeViewSelectionChangeListener);
         treeTableView.setOnMouseClicked(this::treeViewMouseClickHandler);

--- a/gse-app/src/main/java/com/powsybl/gse/app/ProjectPane.java
+++ b/gse-app/src/main/java/com/powsybl/gse/app/ProjectPane.java
@@ -246,7 +246,16 @@ public class ProjectPane extends Tab {
         dateColumn.setCellValueFactory(param -> {
             ZonedDateTime objectModificationDate = null;
             if (param != null && param.getValue() != null && param.getValue().getValue() instanceof ProjectNode) {
-                objectModificationDate = ((ProjectNode) param.getValue().getValue()).getModificationDate();
+                if (param.getValue().getValue() instanceof ProjectFolder) {
+                    objectModificationDate = param.getValue().getChildren().stream().map(child -> {
+                        if (child.getValue() instanceof ProjectNode) {
+                            return ((ProjectNode) child.getValue()).getModificationDate();
+                        }
+                        return null;
+                    }).filter(Objects::nonNull).max(Comparator.naturalOrder()).orElse(((ProjectFolder) param.getValue().getValue()).getModificationDate());
+                } else {
+                    objectModificationDate = ((ProjectNode) param.getValue().getValue()).getModificationDate();
+                }
             }
             return new ReadOnlyObjectWrapper<>(objectModificationDate);
         });

--- a/gse-spi/src/main/java/com/powsybl/gse/spi/ProjectFileMetadataViewerExtension.java
+++ b/gse-spi/src/main/java/com/powsybl/gse/spi/ProjectFileMetadataViewerExtension.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ */
+
+package com.powsybl.gse.spi;
+
+import com.powsybl.afs.ProjectFile;
+
+/**
+ * @author Paul Bui-Quang <paul.buiquang at rte-france.com>
+ */
+public interface ProjectFileMetadataViewerExtension<T extends ProjectFile> {
+
+    Class<T> getProjectFileType();
+
+    String display(T projectFile);
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature


**What is the current behavior?** *(You can also link to an open issue here)*
the date column in project pane is empty and there is no tooltips on objects


**What is the new behavior (if this is a feature change)?**
now that most objects correctly update their last modification date, the column is filled with it.
also a service extension for metadata display was added
