### PR TITLE
Improve copypaste archive management

### DIFF
--- a/gse-app/src/main/java/com/powsybl/gse/app/ProjectPane.java
+++ b/gse-app/src/main/java/com/powsybl/gse/app/ProjectPane.java
@@ -761,7 +761,6 @@ public class ProjectPane extends Tab {
                     }
 
                     List<CopyManager.CopyParams.NodeInfo> nodesInfos = cpInfo.getNodeInfos();
-                    String fileSystemName = cpInfo.getFileSystem();
                     ProjectFolder projectFolder = (ProjectFolder) selectedTreeItem.getValue();
                     String nodeNames = nodesInfos.stream().map(CopyManager.CopyParams.NodeInfo::getName).collect(Collectors.joining(", "));
 

--- a/gse-copy-paste-afs/pom.xml
+++ b/gse-copy-paste-afs/pom.xml
@@ -22,6 +22,12 @@
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-gse-spi</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.resteasy</groupId>
+                    <artifactId>resteasy-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/gse-copy-paste-afs/pom.xml
+++ b/gse-copy-paste-afs/pom.xml
@@ -20,6 +20,10 @@
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-config-classic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
             <artifactId>powsybl-gse-spi</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/gse-copy-paste-afs/pom.xml
+++ b/gse-copy-paste-afs/pom.xml
@@ -20,10 +20,6 @@
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
-            <artifactId>powsybl-config-classic</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.powsybl</groupId>
             <artifactId>powsybl-gse-spi</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/gse-copy-paste-afs/src/main/java/com/powsybl/gse/copy_paste/afs/CopyManager.java
+++ b/gse-copy-paste-afs/src/main/java/com/powsybl/gse/copy_paste/afs/CopyManager.java
@@ -38,7 +38,7 @@ public final class CopyManager {
     private static final String PROJECT_NODE_COPY_TYPE = "@PROJECT_NODE@";
     private static final String NODE_COPY_TYPE = "@NODE@";
     private static final String COPY_SIGNATURE = "@COPY_SIGNATURE@";
-    private static final long COPY_EXPIRATION_TIME = 12;
+    private static final long COPY_EXPIRATION_TIME = 6;
     private static final Logger LOGGER = LoggerFactory.getLogger(CopyManager.class);
     private static final String TEMP_DIR_PREFIX = "powsybl_node_export";
     private static final long CLEANUP_DELAY = 36000;

--- a/gse-copy-paste-afs/src/main/java/com/powsybl/gse/copy_paste/afs/CopyManager.java
+++ b/gse-copy-paste-afs/src/main/java/com/powsybl/gse/copy_paste/afs/CopyManager.java
@@ -7,7 +7,9 @@
 package com.powsybl.gse.copy_paste.afs;
 
 import com.powsybl.afs.*;
+import com.powsybl.commons.config.PlatformConfig;
 import com.powsybl.commons.util.ServiceLoaderCache;
+import com.powsybl.computation.local.LocalComputationManager;
 import com.powsybl.gse.copy_paste.afs.exceptions.*;
 import com.powsybl.gse.spi.ProjectFileExecutionTaskExtension;
 import javafx.scene.input.Clipboard;
@@ -220,8 +222,9 @@ public final class CopyManager {
     }
 
     private Path resolveArchiveTargetDirectory(File directoryProp) throws IOException, CopyNotEmptyArchiveDirectoryException {
+
         if (directoryProp == null) {
-            return Files.createTempDirectory(TEMP_DIR_PREFIX);
+            return Files.createTempDirectory(LocalComputationManager.getDefault().getLocalDir(), TEMP_DIR_PREFIX);
         }
 
         if (!directoryProp.exists() || !directoryProp.canWrite() || !directoryProp.isDirectory()) {
@@ -257,7 +260,6 @@ public final class CopyManager {
     }
 
     private String renameAndPaste(AbstractNodeBase folder, List<? extends AbstractNodeBase> children, CopyInfo info) throws CopyPasteException {
-
         for (AbstractNodeBase child : children) {
             String name = child.getName();
             if (info.node.getName().equals(name)) {

--- a/gse-copy-paste-afs/src/main/java/com/powsybl/gse/copy_paste/afs/CopyManager.java
+++ b/gse-copy-paste-afs/src/main/java/com/powsybl/gse/copy_paste/afs/CopyManager.java
@@ -7,7 +7,6 @@
 package com.powsybl.gse.copy_paste.afs;
 
 import com.powsybl.afs.*;
-import com.powsybl.commons.config.PlatformConfig;
 import com.powsybl.commons.util.ServiceLoaderCache;
 import com.powsybl.computation.local.LocalComputationManager;
 import com.powsybl.gse.copy_paste.afs.exceptions.*;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
copy paste use default tmp directory for archived nodes and do not prevent additionnal copies when disk is full


**What is the new behavior (if this is a feature change)?**
copy paste will use the localcomputation tmp dir to allow more control over this path and also check for disk free space
