### PR TITLE
Fix copied nodes name

### DIFF
--- a/gse-copy-paste-afs/src/main/java/com/powsybl/gse/copy_paste/afs/CopyManager.java
+++ b/gse-copy-paste-afs/src/main/java/com/powsybl/gse/copy_paste/afs/CopyManager.java
@@ -335,7 +335,7 @@ public final class CopyManager {
                 .append(COPY_INFO_SEPARATOR)
                 .append(fileSystemName)
                 .append(COPY_INFO_SEPARATOR);
-        nodes.forEach(nod -> copyParameters.append(nod.getId()).append(COPY_NODE_INFO_SEPARATOR).append(node.getName().replaceAll(COPY_INFO_SEPARATOR, "").replaceAll(COPY_NODE_INFO_SEPARATOR, "")).append(COPY_INFO_SEPARATOR));
+        nodes.forEach(nod -> copyParameters.append(nod.getId()).append(COPY_NODE_INFO_SEPARATOR).append(nod.getName().replaceAll(COPY_INFO_SEPARATOR, "").replaceAll(COPY_NODE_INFO_SEPARATOR, "")).append(COPY_INFO_SEPARATOR));
         return copyParameters;
     }
 


### PR DESCRIPTION
Signed-off-by: Paul Bui-Quang <paul.buiquang@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Name info in copypaste clipboard is always the first node's


**What is the new behavior (if this is a feature change)?**
Names are correct for all copied nodes

