### PR TITLE
Fix refresh project pane handling envents bug

### DIFF
--- a/gse-app/src/main/java/com/powsybl/gse/app/ProjectPane.java
+++ b/gse-app/src/main/java/com/powsybl/gse/app/ProjectPane.java
@@ -169,9 +169,15 @@ public class ProjectPane extends Tab {
 
     private void handleEvent(NodeEvent nodeEvent) {
         ProjectFile projectFile = project.getFileSystem().findProjectFile(nodeEvent.getId(), ProjectFile.class);
+        Timer timer = new Timer();
         if (projectFile != null && projectFile.getProject().getId().equals(getProject().getId())) {
             if (NodeDataUpdated.TYPENAME.equals(nodeEvent.getType()) || DependencyAdded.TYPENAME.equals(nodeEvent.getType())) {
-                refreshProjectFile(projectFile);
+                timer.schedule(new TimerTask() {
+                    @Override
+                    public void run() {
+                        refreshProjectFile(projectFile);
+                    }
+                }, 1000);
             } else if (NodeNameUpdated.TYPENAME.equals(nodeEvent.getType())) {
                 List<ProjectFile> backwardDependencies = projectFile.getBackwardDependencies();
                 backwardDependencies.forEach(this::refreshProjectFile);

--- a/gse-app/src/main/java/com/powsybl/gse/app/ProjectPane.java
+++ b/gse-app/src/main/java/com/powsybl/gse/app/ProjectPane.java
@@ -198,7 +198,7 @@ public class ProjectPane extends Tab {
         allTreeItems.addAll(children);
         children.stream()
                 .filter(item -> item.getValue() instanceof ProjectNode)
-                .filter(item -> item.getValue() instanceof ProjectNode && ((ProjectNode) item.getValue()).isFolder())
+                .filter(item -> ((ProjectNode) item.getValue()).isFolder())
                 .forEach(folderItem -> findAllTreeItems(folderItem, allTreeItems));
     }
 

--- a/gse-app/src/main/java/com/powsybl/gse/app/ProjectPane.java
+++ b/gse-app/src/main/java/com/powsybl/gse/app/ProjectPane.java
@@ -168,7 +168,7 @@ public class ProjectPane extends Tab {
     }
 
     private void handleEvent(NodeEvent nodeEvent) {
-        if (NodeDataRemoved.TYPENAME.equals(nodeEvent.getType())) {
+        if (NodeDataRemoved.TYPENAME.equals(nodeEvent.getType()) || NodeRemoved.TYPENAME.equals(nodeEvent.getType())) {
             //Deleted node can not be fetched
             return;
         }


### PR DESCRIPTION
Signed-off-by: Nassirou NAMBIEMA <nassirou.nambiena@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
no


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
when creating a new node in the tree view of the project pane, the tree item first considers the value of the node as a string, therefore when updating the projectNode contained by the item, a ClassCastException is thrown.


**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*
no breaking change

**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
