### PR TITLE
Reposition Rename Button bar when importing files

### DIFF
--- a/gse-afs-ext-base/src/main/java/com/powsybl/gse/afs/ext/base/ImportedCaseCreator.java
+++ b/gse-afs-ext-base/src/main/java/com/powsybl/gse/afs/ext/base/ImportedCaseCreator.java
@@ -196,7 +196,7 @@ public class ImportedCaseCreator extends GridPane implements ProjectFileCreator 
                         projectNode.rename(name);
                     }
                 });
-            } else if (buttonType.getButtonData() == ButtonBar.ButtonData.OTHER) {
+            } else if (buttonType.getButtonData() == ButtonBar.ButtonData.NO) {
                 folder.getChild(name).ifPresent(projectNode -> {
                     Optional<String> text = GseUtil.runOnPlatformAndWait(() -> RenamePane.showAndWaitDialog(scene.getWindow(), projectNode).orElse(null));
                     text.ifPresent(newName -> {

--- a/gse-util/src/main/java/com/powsybl/gse/util/GseAlerts.java
+++ b/gse-util/src/main/java/com/powsybl/gse/util/GseAlerts.java
@@ -82,7 +82,7 @@ public final class GseAlerts {
         alert.setHeaderText(MessageFormat.format(RESOURCE_BUNDLE.getString("ReplaceFile"), documentName));
         alert.setContentText(MessageFormat.format(RESOURCE_BUNDLE.getString("FileWithTheSameNameExists"), folderName));
         ButtonType replace = new ButtonType(RESOURCE_BUNDLE.getString("Replace"), ButtonBar.ButtonData.YES);
-        ButtonType rename = new ButtonType(RESOURCE_BUNDLE.getString("Rename"), ButtonBar.ButtonData.OTHER);
+        ButtonType rename = new ButtonType(RESOURCE_BUNDLE.getString("Rename"), ButtonBar.ButtonData.NO);
         alert.getButtonTypes().setAll(replace, rename, ButtonType.CANCEL);
         alert.getDialogPane().setPrefWidth(600);
         alert.getDialogPane().setPrefHeight(170);


### PR DESCRIPTION
Signed-off-by: Nassirou NAMBIEMA <nassirou.nambiena@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
no


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Button Bar  positioning differs between windows and linux . the replace and rename buttons are distant in windows  because rename' s button bar are set to OTHER while replace Button's bar are set to YES


**What is the new behavior (if this is a feature change)?**
Button Bar  positioning are the same between Windows et Linux 


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*
no breaking change

**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
